### PR TITLE
Fix NodeNetworkPolicy e2e test failure

### DIFF
--- a/multicluster/test/e2e/antreapolicy_test.go
+++ b/multicluster/test/e2e/antreapolicy_test.go
@@ -33,10 +33,10 @@ const (
 )
 
 var (
-	allPodsPerCluster    []antreae2e.Pod
+	allPodsPerCluster    []*antreae2e.Pod
 	perNamespacePods     []string
 	perClusterNamespaces map[string]antreae2e.TestNamespaceMeta
-	podsByNamespace      map[string][]antreae2e.Pod
+	podsByNamespace      map[string][]*antreae2e.Pod
 	clusterK8sUtilsMap   map[string]*antreae2e.KubernetesUtils
 )
 
@@ -58,8 +58,8 @@ func initializeForPolicyTest(t *testing.T, data *MCTestData) {
 		perClusterNamespaces[ns] = antreae2e.TestNamespaceMeta{Name: ns}
 	}
 
-	allPodsPerCluster = []antreae2e.Pod{}
-	podsByNamespace = make(map[string][]antreae2e.Pod)
+	allPodsPerCluster = []*antreae2e.Pod{}
+	podsByNamespace = make(map[string][]*antreae2e.Pod)
 	clusterK8sUtilsMap = make(map[string]*antreae2e.KubernetesUtils)
 
 	for _, podName := range perNamespacePods {
@@ -73,7 +73,7 @@ func initializeForPolicyTest(t *testing.T, data *MCTestData) {
 		k8sUtils, err := antreae2e.NewKubernetesUtils(&d)
 		failOnError(err, t)
 		if clusterName != leaderCluster {
-			_, err = k8sUtils.Bootstrap(perClusterNamespaces, perNamespacePods, true, nil, nil)
+			_, err = k8sUtils.Bootstrap(perClusterNamespaces, true, allPodsPerCluster)
 			failOnError(err, t)
 		}
 		clusterK8sUtilsMap[clusterName] = k8sUtils

--- a/test/e2e/antreaipam_anp_test.go
+++ b/test/e2e/antreaipam_anp_test.go
@@ -39,8 +39,8 @@ func initializeAntreaIPAM(t *testing.T, data *TestData) {
 	// This function "initializeAntreaIPAM" will be used more than once, and variable "allPods" is global.
 	// It should be empty every time when "initializeAntreaIPAM" is performed, otherwise there will be unexpected
 	// results.
-	allPods = []Pod{}
-	podsByNamespace = make(map[string][]Pod)
+	allPods = []*Pod{}
+	podsByNamespace = make(map[string][]*Pod)
 	for _, ns := range antreaIPAMNamespaces {
 		namespaces[ns] = TestNamespaceMeta{Name: ns}
 	}
@@ -55,9 +55,9 @@ func initializeAntreaIPAM(t *testing.T, data *TestData) {
 	// k8sUtils is a global var
 	k8sUtils, err = NewKubernetesUtils(data)
 	failOnError(err, t)
-	_, err = k8sUtils.Bootstrap(regularNamespaces, podsPerNamespace, true, nil, nil)
+	_, err = k8sUtils.Bootstrap(regularNamespaces, true, allPods)
 	failOnError(err, t)
-	ips, err := k8sUtils.Bootstrap(namespaces, podsPerNamespace, false, nil, nil)
+	ips, err := k8sUtils.Bootstrap(namespaces, false, allPods)
 	failOnError(err, t)
 	podIPs = ips
 }


### PR DESCRIPTION
In NodeNetworkPolicy e2e tests, we have the following cases:

- Node to Node. We deploy two hostNetwork Pods on different Nodes.
- Node to Pods. We deploy a hostNetwork Pod on a Node and two non-hostNetwork Pods on different Nodes.

For the case of Node to Pods, after creating test Pods, a full mesh probing is run to ensure that all Pods can be reachable from each other. However, the UDP probing from a non-hostNetwork Pod to the hostNetwork Pod deployed on the same Node will get a failure. The reason is that due to UDP's connectionless nature, the reply traffic may use a source IP address determined by routing decisions or outgoing interfaces, rather than the destination IP address used in request traffic. This can lead to probing failures for the UDP server.

To resolve the issue, we ensure that the UDP server listens exclusively on Node IPs when the test Pod is a host network Pod.